### PR TITLE
Target Selection Usability

### DIFF
--- a/hubverse_annotator/app.py
+++ b/hubverse_annotator/app.py
@@ -207,22 +207,21 @@ def main() -> None:
             options=targets_available,
             key="target_selection",
         )
+        smhubt_to_plot = pl.DataFrame()
+        eh_to_plot = pl.DataFrame()
         if (selected_models) and (selected_target is not None):
             smhubt_to_plot = smhubt_by_loc.filter(
                 pl.col("model").is_in(selected_models),
                 pl.col("target") == selected_target,
             )
-            eh_to_plot = eh_table.filter(
-                pl.col("location") == two_num_loc_abbr,
-                pl.col("target") == selected_target,
-            )
-        else:
-            smhubt_to_plot = pl.DataFrame()
-            eh_to_plot = pl.DataFrame()
+            if not eh_table.is_empty():
+                eh_to_plot = eh_table.filter(
+                    pl.col("location") == two_num_loc_abbr,
+                    pl.col("target") == selected_target,
+                )
         st.markdown(f"## Forecasts For: {two_letter_loc_abbr}")
         st.markdown(f"## Reference Date: {selected_ref_date}")
         forecast_layers = create_quantile_forecast_chart(smhubt_to_plot)
-
         observed_layers = target_data_chart(eh_to_plot)
         forecast_and_observed_layers = forecast_layers + observed_layers
         chart = (


### PR DESCRIPTION
For the scope of this PR, please see issue #11 .

Specifically, this PR adds:

* [x] Available targets filtered by which models have been selected.
* [x] First entry default, but without `session_state`.
* [x] Default to empty plotting dataframe if no targets selected. 
* [x] Forecast chart argument corrected to `chart` from `forecast_layers`. 
* [x] Default, empty dataframes for plotting if file not uploaded.

