### PR TITLE
Improvements To Hubverse Loading Function

### DIFF
--- a/hubverse_annotator/app.py
+++ b/hubverse_annotator/app.py
@@ -141,7 +141,6 @@ def load_hubverse_table(hub_file: UploadedFile | None):
     else:
         st.error(f"Unsupported file type: {ext}")
         st.stop()
-    # st.success(f"Loaded {hub_file.name} ({ext}).")
     logger.info(f"Uploaded file:\n{hub_file.name}")
     n_rows, n_cols = hub_table.shape
     size_bytes = hub_table.estimated_size()


### PR DESCRIPTION
For the full scope of this PR, please refer to issue #49 .

Specifically, this PR:

* [x] Adds a docstring to the `load_hubverse_table()` in `app.py`.
* [x] Switches the order in which an empty Polars dataframe is made in `load_hubverse_table()` in `app.py`
* [x] Adds typehints to `load_hubverse_table()` in `app.py`.