### PR TITLE
Default Theme

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,5 @@
+[browser]
+gatherUsageStats = false
+
+[theme]
+base = "light"


### PR DESCRIPTION
For the full scope of this PR, please refer to issue #40 .

Specifically, this PR adds:

* [x] A theme file called `config.toml`, in a directory called `.streamlit`, within `.`, i.e. the directory from which `app.py` is ran. 
* [x] The default `base` theme set to `light` in `config.toml`.
* [x] Telemetry disabled in `config.toml`.

See the issue for some notes.