### PR TITLE
Correction To Arrow Key Bindings

### DIFF
--- a/hubverse_annotator/app.py
+++ b/hubverse_annotator/app.py
@@ -31,6 +31,8 @@ PLOT_WIDTH = 625
 STROKE_WIDTH = 2
 MARKER_SIZE = 25
 
+add_shortcuts(prev_button="arrowleft", next_button="arrowright")
+
 
 def export_button() -> None:
     """
@@ -267,7 +269,6 @@ def location_and_reference_data_ui(
             on_click=go_to_next_loc,
             key="next_button",
         )
-    add_shortcuts(prev_button="arrowleft", next_button="arrowright")
     loc_id = st.session_state.current_loc_id
     selected_location = st.session_state.locations_list[loc_id]
     loc_abbr = (


### PR DESCRIPTION
This PR fixes an issue that was introduced to `main` in #79 . In my verification of the pull request changes pre-merge for this PR, I must have not fully restarted and refreshed the application following <https://github.com/CDCgov/hubverse-annotator/pull/84/commits/406936c3163f722bcba0ab763cf631d9af32c2d8> and <https://github.com/CDCgov/hubverse-annotator/pull/84/commits/e097e23c6585c82ee3b819af78a0d2a43bc6c775>. 

The issue encountered: when one first loads the application and then uploads a file, the arrow keys work for a single press of Next or Prev (depending on the value of the selected location from the `selectbox`) but freeze after. If the page is refreshed, the observations / forecast file re-uploaded, the arrow keys work as normal. 

The change I have introduced in this PR makes it so that the arrow keys fully work on the first loading of a file (observations or forecast) and do not require a re-fresh of the page. The solution was to move this line

`add_shortcuts(prev_button="arrowleft", next_button="arrowright")`

out of the `location_and_reference_date_ui` function and to the top of the file.

Between the first and second video, I fully closed down the streamlit app and reopen a new session.

<details markdown=1>

<summary> Before The Change </summary>



https://github.com/user-attachments/assets/36b0a48f-7a33-406b-9b92-01b21489da3f

</details>


<details markdown=1>

<summary> After The Change </summary>



https://github.com/user-attachments/assets/da7a04f4-8728-4fe8-96fb-9fa11cfce21b


</details>

