### PR TITLE
Default Plot, Targets, And Selections

### DIFF
--- a/hubverse_annotator/app.py
+++ b/hubverse_annotator/app.py
@@ -543,55 +543,6 @@ def quantile_forecast_chart(
     return alt.layer(band_95, band_80, band_50, median)
 
 
-def _cut_observed_to_forecast(
-    observed_data_table: pl.DataFrame,
-    forecast_table: pl.DataFrame,
-    observed_date_col: str = "date",
-    forecast_date_col: str = "target_end_date",
-    extra_weeks: int = 1,
-) -> pl.DataFrame:
-    """
-    Crops the observed data table so that its dates do not
-    extend more than `extra_weeks` beyond the latest
-    forecast date.
-
-    Parameters
-    ----------
-    observed_data_table : pl.DataFrame
-        A hubverse table of loaded data (possibly empty).
-    forecast_table : pl.DataFrame
-        The hubverse formatted table of forecasted ED
-        visits and or hospital admissions (possibly empty).
-    observed_date_col
-        Name of the date column in `observed_data_table`.
-    forecast_date_col
-        Name of the date column in `forecast_table`.
-    extra_weeks
-        Number of weeks beyond the min forecast date to
-        retain in the `observed_data_table`.
-
-    Returns
-    -------
-    pl.DataFrame
-        Filtered `observed_data_table` where
-        `obs_date_col` is GEQ min(forecast_table
-        [forecast_date_col]) plus `extra_weeks`.
-    """
-    observed = observed_data_table.with_columns(
-        pl.col(observed_date_col).cast(pl.Date)
-    )
-    forecasts = forecast_table.with_columns(
-        pl.col(forecast_date_col).cast(pl.Date)
-    )
-
-    min_date_forecast = forecasts.select(
-        pl.col(forecast_date_col).min()
-    ).item()
-    cutoff = min_date_forecast - datetime.timedelta(weeks=extra_weeks)
-
-    return observed.filter(pl.col(observed_date_col) >= cutoff)
-
-
 def plotting_ui(
     data_to_plot: pl.DataFrame,
     forecasts_to_plot: pl.DataFrame,
@@ -698,14 +649,6 @@ def filter_for_plotting(
         pl.col("model_id").is_in(selected_models),
         pl.col("reference_date") == selected_ref_date,
     )
-    if not data_to_plot.is_empty() and not forecasts_to_plot.is_empty():
-        data_to_plot = _cut_observed_to_forecast(
-            observed_data_table=data_to_plot,
-            forecast_table=forecasts_to_plot,
-            observed_date_col="date",
-            forecast_date_col="target_end_date",
-            extra_weeks=4,
-        )
     return data_to_plot, forecasts_to_plot
 
 


### PR DESCRIPTION
For the full scope of this PR, please refer to issue #75 .

Specifically, this PR adds:

* [x] A button called `All` underneath the model selectbox that selects all models.
* [x] A button called `None` underneath the model selectbox that de-selects all models.
* [x] The default for the model selectbox set to all models.
* [x] Edits to the Next and Previous buttons to abide better with PEP-008, i.e. "_single_leading_underscore: weak “internal use” indicator."
* [x] Target selection defaults to the first target, alphabetically.
* [-] A function called `_cut_observed_to_forecast` that truncates the observations to be `extra_weeks` longer than the minimum forecast date.
* [x] The default for reference to be the most recent reference date.

Somewhat out-of-scope but still useful, this PR also adds:

* [x] Two functions `target_selection_ui` and `model_selection_ui` in place of `model_and_target_selection_ui`, to keep the code more organized and atomic; corresponding updates have been made in `main`.
* [x] Two functions `location_selection_ui` and `reference_date_selection_ui` in place of `location_and_reference_data_ui`, again to keep the code more organized and atomic; corresponding updates have been made in `main`.
