### PR TITLE
Fix Next And Previous Button Alignment With Add-Shortcuts

### DIFF
--- a/hubverse_annotator/ui.py
+++ b/hubverse_annotator/ui.py
@@ -250,7 +250,7 @@ def location_selection_ui(
             "⏮️",
             disabled=(st.session_state.current_loc_id == 0),
             on_click=_go_to_prev_loc,
-            key="prev_button",
+            key="prev_loc_button",
         )
     with next_col:
         st.button(
@@ -260,9 +260,9 @@ def location_selection_ui(
                 == len(st.session_state.locations_list) - 1
             ),
             on_click=_go_to_next_loc,
-            key="next_button",
+            key="next_loc_button",
         )
-    add_shortcuts(prev_button="arrowleft", next_button="arrowright")
+    add_shortcuts(prev_loc_button="arrowleft", next_loc_button="arrowright")
     loc_id = st.session_state.current_loc_id
     selected_location = st.session_state.locations_list[loc_id]
     loc_abbr = (


### PR DESCRIPTION
This PR fixes the alignment of the Next and Previous buttons using `add_shortcuts` over `shortcut_button` from the package `streamlit_shortcuts`. 

In an issue (see <https://github.com/adriangalilea/streamlit-shortcuts/issues/33>), the `streamlit_shortcuts` developers recommend using `add_shortcuts` until `shortcut_button` was fixed, for which no timeline was given.

This PR changes the following

```python
with prev_col:
        shortcut_button(
            label="⏮️",
            hint=False,
            shortcut="arrowleft",
            disabled=(st.session_state.current_loc_id == 0),
            on_click=_go_to_prev_loc,
            use_container_width=True,
        )
    with next_col:
        shortcut_button(
            label="⏭️",
            hint=False,
            shortcut="arrowright",
            disabled=(
                st.session_state.current_loc_id
                == len(st.session_state.locations_list) - 1
            ),
            on_click=_go_to_next_loc,
            use_container_width=True,
        )
```

<details markdown=1>

<summary> Shortcut Button Appearence </summary>

<img width="1133" height="751" alt="Screenshot 2025-07-31 at 09 20 26" src="https://github.com/user-attachments/assets/0abd2771-c026-467a-bed7-f27ce3018fb7" />


</details>

to 

```python
with prev_col:
        st.button(
            "⏮️",
            disabled=(st.session_state.current_loc_id == 0),
            on_click=_go_to_prev_loc,
            key="prev_button",
        )
    with next_col:
        st.button(
            "⏭️",
            disabled=(
                st.session_state.current_loc_id
                == len(st.session_state.locations_list) - 1
            ),
            on_click=_go_to_next_loc,
            key="next_button",
        )
    add_shortcuts(prev_button="arrowleft", next_button="arrowright")
```

<details markdown=1>

<summary> Add Shortcuts Appearence </summary>

<img width="1135" height="753" alt="Screenshot 2025-07-31 at 09 24 01" src="https://github.com/user-attachments/assets/0877f18b-4a53-424e-af1e-98653b7fdc31" />



</details>

Note that I also tried `shortcut_button` with `use_container_width=False` but this has no discernable effect:

<details markdown=1>

<summary> Shortcut Button Container Width False </summary>

<img width="1132" height="752" alt="Screenshot 2025-07-31 at 09 21 34" src="https://github.com/user-attachments/assets/e7415b14-a661-4507-bf7d-174a65e91018" />


</details>

This PR was tested on Safari version 16.4.
