### PR TITLE
Order Reference Dates From Oldest To Newest

### DIFF
--- a/hubverse_annotator/ui.py
+++ b/hubverse_annotator/ui.py
@@ -322,6 +322,7 @@ def reference_date_selection_ui(
 
     if "ref_dates" not in st.session_state:
         st.session_state.ref_dates = ref_dates.copy()
+        st.session_state.current_ref_date_id = len(ref_dates) - 1
 
     def _go_to_prev_ref_date():
         st.session_state.current_ref_date_id -= 1
@@ -332,10 +333,11 @@ def reference_date_selection_ui(
     ref_date_col, prev_col, next_col = st.columns(
         [6, 1, 1], vertical_alignment="bottom"
     )
+    num_ref_dates = len(st.session_state.ref_dates)
     with ref_date_col:
         st.selectbox(
             "Reference Date",
-            options=list(range(len(st.session_state.ref_dates))),
+            options=list(range(num_ref_dates)),
             key="current_ref_date_id",
             format_func=lambda i: st.session_state.ref_dates[i].strftime(
                 "%Y-%m-%d"


### PR DESCRIPTION
This PR:

* [x] Removes the `reverse = True` from the `ref_date` sorting in `reference_date_selection_ui` so that the reference dates go least recent to most recent.