### PR TITLE
Quantile Forecast Chart Simplification

### DIFF
--- a/hubverse_annotator/utils.py
+++ b/hubverse_annotator/utils.py
@@ -304,7 +304,9 @@ def quantile_forecast_chart(
             ``low`` to ``high``, with step interpolation.
         """
         return base.mark_errorband(opacity=opacity, interpolate="step").encode(
-            y=f"{low}:Q", y2=f"{high}:Q", fill=alt.value("steelblue")
+            y=alt.Y(f"{low}:Q", title=f"{selected_target}"),
+            y2=f"{high}:Q",
+            fill=alt.value("steelblue"),
         )
 
     bands = [


### PR DESCRIPTION
For the full scope of this PR, please refer to issue #18 .

Specifically, this PR:

* [x] Refactors the function `quantile_forecast_chart` in `utils.py` 
  * [x] to use a helper function `band`.
  * [x] to remove each individual `scale` argument for log-scale.