### PR TITLE
Cast Output Type ID As String

### DIFF
--- a/hubverse_annotator/utils.py
+++ b/hubverse_annotator/utils.py
@@ -558,7 +558,7 @@ def load_forecast_data(
     table = (
         load_hubverse_table(forecast_file)
         .select(forecast_schema.keys())
-        .cast({"horizon": pl.Float64})
+        .cast({"horizon": pl.Float64, "output_type_id": pl.Utf8})
     )
     validate_schema(table, forecast_schema, "Forecast Data")
     return table


### PR DESCRIPTION
This PR casts `output_type_id` as `str` to ensure the annotator works with present `pyrenew-hew` output.